### PR TITLE
Sound: initialize StreamInfo

### DIFF
--- a/crates/sound/src/audio_backends/null.rs
+++ b/crates/sound/src/audio_backends/null.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
 
 use super::AudioBackend;
-use crate::{Error, Result};
+use crate::Result;
 
 pub struct NullBackend {}
 

--- a/crates/sound/src/audio_backends/pw_backend.rs
+++ b/crates/sound/src/audio_backends/pw_backend.rs
@@ -4,22 +4,11 @@
 use super::AudioBackend;
 use std::{thread};
 use std::{cell::Cell, rc::Rc};
-use crate::{Error, Result};
+use crate::Result;
 
-use vm_memory::{Le32, Le64};
+use vm_memory::Le32;
 use pipewire as pw;
-use pw::{sys::*};
-
-#[derive(Default, Debug)]
-pub struct StreamInfo {
-    pub id: usize,
-    pub params: PCMParams,
-    pub formats: Le64,
-    pub rates: Le64,
-    pub direction: u8,
-    pub channels_min: u8,
-    pub channels_max: u8,
-}
+use pw::sys::PW_ID_CORE;
 
 #[derive(Default, Debug)]
 pub struct PCMParams {


### PR DESCRIPTION
This commit adds a vector named StreamInfo that contains the supported configuration for the audio backends, e.g., rate, format. This information is stored in the context of VhostUserSoundBackend. The device reponses this information when getting the VIRTIO_SND_R_PCM_INFO msg. The number of streams that are exposed in the device configuration is got from this table.