### PR TITLE
sound: always compile null backend

### DIFF
--- a/crates/sound/Cargo.toml
+++ b/crates/sound/Cargo.toml
@@ -10,8 +10,7 @@ license = "Apache-2.0 OR BSD-3-Clause"
 edition = "2018"
 
 [features]
-default = ["null-backend", "alsa-backend", "pw-backend"]
-null-backend = []
+default = ["alsa-backend", "pw-backend"]
 alsa-backend = ["dep:alsa"]
 pw-backend = ["pipewire", "libspa", "pipewire-sys", "libspa-sys", "bindgen"]
 

--- a/crates/sound/src/audio_backends.rs
+++ b/crates/sound/src/audio_backends.rs
@@ -3,7 +3,6 @@
 
 #[cfg(feature = "alsa-backend")]
 mod alsa;
-#[cfg(feature = "null-backend")]
 mod null;
 
 #[cfg(feature = "pw-backend")]
@@ -13,11 +12,10 @@ use std::sync::{Arc, RwLock};
 
 #[cfg(feature = "alsa-backend")]
 use self::alsa::AlsaBackend;
-#[cfg(feature = "null-backend")]
 use self::null::NullBackend;
 #[cfg(feature = "pw-backend")]
 use self::pipewire::PwBackend;
-use crate::{device::ControlMessage, stream::Stream, BackendType, Error, Result};
+use crate::{device::ControlMessage, stream::Stream, BackendType, Result};
 
 pub trait AudioBackend {
     fn write(&self, stream_id: u32) -> Result<()>;
@@ -47,23 +45,14 @@ pub trait AudioBackend {
 
 pub fn alloc_audio_backend(
     backend: BackendType,
-    // Unused when compiled with no features.
-    #[allow(unused_variables)] streams: Arc<RwLock<Vec<Stream>>>,
+    streams: Arc<RwLock<Vec<Stream>>>,
 ) -> Result<Box<dyn AudioBackend + Send + Sync>> {
     log::trace!("allocating audio backend {:?}", backend);
     match backend {
-        #[cfg(feature = "null-backend")]
         BackendType::Null => Ok(Box::new(NullBackend::new(streams))),
         #[cfg(feature = "pw-backend")]
         BackendType::Pipewire => Ok(Box::new(PwBackend::new(streams))),
         #[cfg(feature = "alsa-backend")]
         BackendType::Alsa => Ok(Box::new(AlsaBackend::new(streams))),
-        // By default all features are enabled and this branch is unreachable.
-        // Nonetheless, it is required when inidividual features (or no features
-        // at all) are enabled.
-        // To avoid having a complicated compilation condition and make the
-        // code more maintainable, we supress the unreachable_patterns warning.
-        #[allow(unreachable_patterns)]
-        _ => Err(Error::AudioBackendNotSupported),
     }
 }

--- a/crates/sound/src/lib.rs
+++ b/crates/sound/src/lib.rs
@@ -95,7 +95,9 @@ impl From<stream::Error> for Error {
 pub enum BackendType {
     #[default]
     Null,
+    #[cfg(feature = "pw-backend")]
     Pipewire,
+    #[cfg(feature = "alsa-backend")]
     Alsa,
 }
 

--- a/crates/sound/src/main.rs
+++ b/crates/sound/src/main.rs
@@ -69,8 +69,11 @@ mod tests {
     #[rstest]
     #[serial]
     #[case::null_backend("null", BackendType::Null)]
-    #[case::pipewire("pipewire", BackendType::Pipewire)]
-    #[case::alsa("alsa", BackendType::Alsa)]
+    #[cfg_attr(
+        feature = "pw-backend",
+        case::pipewire("pipewire", BackendType::Pipewire)
+    )]
+    #[cfg_attr(feature = "alsa-backend", case::alsa("alsa", BackendType::Alsa))]
     fn test_cli_backend_arg(#[case] backend_name: &str, #[case] backend: BackendType) {
         let args: SoundArgs = Parser::parse_from([
             "",


### PR DESCRIPTION
Make Null backend compiled unconditionally,
removing the null-backend feature. That
allows having the other backend choices in
the BackendType enum to be conditional, and
make them not available if their features is
opted out at compile time.

For example, compiled with no backend features,
there is only choice (i.e., null) for --backend:

```
$ target/debug/vhost-user-sound --help

Usage: vhost-user-sound --socket <SOCKET> --backend <BACKEND>

Options:
      --socket <SOCKET>    vhost-user Unix domain socket path
      --backend <BACKEND>  audio backend to be used [possible values: null]
  -h, --help               Print help
  -V, --version            Print version
```

Fixes: #26