### PR TITLE
sound/pipewire: move stream_hash insert into lock

### DIFF
--- a/crates/sound/src/audio_backends/pipewire.rs
+++ b/crates/sound/src/audio_backends/pipewire.rs
@@ -385,10 +385,10 @@ impl AudioBackend for PwBackend {
                 )
                 .expect("could not connect to the stream");
 
-            lock_guard.unlock();
-
             // insert created stream in a hash table
             stream_hash.insert(stream_id, stream);
+
+            lock_guard.unlock();
         }
 
         Ok(())


### PR DESCRIPTION
Inserting a new stream into stream_hash can potentially move out of context a stream previously stored in the hash with the same id, triggering pw::stream::Stream::Drop, which calls pw_stream_destroy.

As calls to the pipewire library must happen either in the pipewire thread or under thread_loop lock protection, move the insert into stream_hash under the latter.