### PR TITLE
Draft: Try to fill up to period_bytes

### DIFF
--- a/crates/sound/src/audio_backends/pipewire.rs
+++ b/crates/sound/src/audio_backends/pipewire.rs
@@ -385,10 +385,10 @@ impl AudioBackend for PwBackend {
                 )
                 .expect("could not connect to the stream");
 
-            lock_guard.unlock();
-
             // insert created stream in a hash table
             stream_hash.insert(stream_id, stream);
+
+            lock_guard.unlock();
         }
 
         Ok(())


### PR DESCRIPTION
Ideally, each time process() is called, we should fill the buffer with as much data we have, up to period_bytes. Failure to do so, in addition to being less efficient, can lead to cracking sounds under certain circumstances.

This one goes on top of #32 